### PR TITLE
Fix variable-byte encoding of large longs

### DIFF
--- a/src/main/java/me/lemire/longcompression/LongVariableByte.java
+++ b/src/main/java/me/lemire/longcompression/LongVariableByte.java
@@ -90,7 +90,7 @@ public class LongVariableByte implements LongCODEC, ByteLongCODEC, SkippableLong
                 buf.put((byte) extract7bits(5, val));
                 buf.put((byte) extract7bits(6, val));
                 buf.put((byte) (extract7bitsmaskless(7, (val)) | (1 << 7)));
-            } else if (val >= 0 && val < (1L << 63)) {
+            } else if (val >= 0) {
                 buf.put((byte) extract7bits(0, val));
                 buf.put((byte) extract7bits(1, val));
                 buf.put((byte) extract7bits(2, val));
@@ -175,7 +175,7 @@ public class LongVariableByte implements LongCODEC, ByteLongCODEC, SkippableLong
                 out[outpostmp++] = (byte) extract7bits(5, val);
                 out[outpostmp++] = (byte) extract7bits(6, val);
                 out[outpostmp++] = (byte) (extract7bitsmaskless(7, (val)) | (1 << 7));
-            } else if (val >= 0 && val < (1L << 63)) {
+            } else if (val >= 0) {
                 out[outpostmp++] = (byte) extract7bits(0, val);
                 out[outpostmp++] = (byte) extract7bits(1, val);
                 out[outpostmp++] = (byte) extract7bits(2, val);

--- a/src/test/java/me/lemire/longcompression/TestLongVariableByte.java
+++ b/src/test/java/me/lemire/longcompression/TestLongVariableByte.java
@@ -24,11 +24,17 @@ public class TestLongVariableByte extends ATestLongCODEC {
 	}
 
 	@Test
-	public void testCodec_intermediateHighPowerOfTwo() {
-		Assert.assertEquals(1, LongTestUtils.compress((LongCODEC) codec, new long[] { 1L << 42 }).length);
-		Assert.assertEquals(7, LongTestUtils.compress((ByteLongCODEC) codec, new long[] { 1L << 42 }).length);
-		Assert.assertEquals(1,
-				LongTestUtils.compressHeadless((SkippableLongCODEC) codec, new long[] { 1L << 42 }).length);
-	}
+	public void testCodec_allBitWidths() {
+		for (int bitWidth = 0; bitWidth <= 64; bitWidth++) {
+			long value = bitWidth == 0 ? 0 : 1L << (bitWidth - 1);
 
+			int expectedSizeInBytes = Math.max(1, (bitWidth + 6) / 7);
+			int expectedSizeInLongs = (expectedSizeInBytes > 8) ? 2 : 1;
+
+			Assert.assertEquals(expectedSizeInLongs, LongTestUtils.compress((LongCODEC) codec, new long[] { value }).length);
+			Assert.assertEquals(expectedSizeInBytes, LongTestUtils.compress((ByteLongCODEC) codec, new long[] { value }).length);
+			Assert.assertEquals(expectedSizeInLongs,
+					LongTestUtils.compressHeadless((SkippableLongCODEC) codec, new long[] { value }).length);
+		}
+	}
 }


### PR DESCRIPTION
Previously, the branch encoding longs in 9 bytes was unreachable because the condition `val < (1L << 63)` is always false. Only negative longs should be encoded using 10 bytes.